### PR TITLE
Add build scripts for server and client

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "dev:server": "pnpm run --filter server dev",
     "dev:client": "pnpm run --filter client dev",
+    "build:server": "pnpm run --filter server build",
+    "build:client": "pnpm run --filter client build",
     "dev": "pnpm run --parallel -r dev",
     "build": "pnpm run --parallel -r build",
     "lint": "biome check .",


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to add build scripts for both the server and client. These changes enhance the development workflow by allowing separate build commands for the server and client.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13-R14): Added `build:server` and `build:client` scripts to the `scripts` section for building the server and client separately.