### PR TITLE
Add Jest and related dependencies for testing

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "test": "jest",
     "prisma:generate": "prisma generate",
     "prisma:push": "prisma db push",
     "postinstall": "prisma generate"
@@ -34,15 +35,21 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.7",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^20.2.3",
     "@types/nodemailer": "^6.4.16",
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.16",
+    "@types/supertest": "^6.0.2",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -19,15 +19,23 @@
     "lint:fix": "biome check . --apply",
     "prepare": "is-ci || husky install",
     "db:generate": "pnpm run --filter server prisma:generate",
-    "db:push": "pnpm run --filter server prisma:push"
+    "db:push": "pnpm run --filter server prisma:push",
+    "test": "jest",
+    "test:server": "pnpm run --filter server test",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.3",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.14",
     "concurrently": "^8.2.2",
     "husky": "^9.0.11",
-    "lint-staged": "^15.2.10"
+    "jest": "^29.7.0",
+    "lint-staged": "^15.2.10",
+    "ts-jest": "^29.2.5"
   },
   "dependencies": {
     "@tubenote/shared": "link:packages/shared",


### PR DESCRIPTION
This pull request introduces Jest for testing in the server application and updates the `package.json` files to include necessary dependencies and scripts for running tests. The most important changes include adding Jest and related dependencies, as well as new test scripts.

### Testing Setup:

* [`apps/server/package.json`](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R11): Added Jest as a test framework and included related dependencies like `@jest/globals`, `@types/jest`, `supertest`, and `ts-jest`. Also, added a new script to run tests using Jest. [[1]](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R11) [[2]](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R38-R52)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R38): Added Jest and related dependencies to the root `package.json` file. Added new scripts to run tests, watch tests, and generate test coverage reports.