### PR TITLE
Create shared redis-cache package and refactor bff/server apps to use it

### DIFF
--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tubenote/api-errors": "workspace:*",
+    "@tubenote/redis-cache": "workspace:*",
     "axios": "^1.10.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
@@ -20,7 +21,6 @@
     "express-async-errors": "^3.1.1",
     "helmet": "^8.0.0",
     "http-status": "^1.8.1",
-    "ioredis": "^5.6.1",
     "uuid": "^11.1.0",
     "zod": "^3.23.8"
   },

--- a/apps/bff/src/modules/auth/auth.service.ts
+++ b/apps/bff/src/modules/auth/auth.service.ts
@@ -8,11 +8,11 @@ import type { ISessionData } from "@/services";
 
 import { envConfig } from "@/config";
 import { axiosInstance } from "@/lib/axios";
-import { redisSessionService } from "@/services";
+import { sessionCacheService } from "@/services";
 
 export class AuthService {
   async getSession(sessionId: string): Promise<ISessionData | null> {
-    return redisSessionService.getSession(sessionId);
+    return sessionCacheService.getSession(sessionId);
   }
 
   async register(credentials: IRegisterDto): Promise<IApiSuccessResponse<string>> {
@@ -28,7 +28,7 @@ export class AuthService {
 
     const sessionId = uuidv4();
 
-    await redisSessionService.createSession(sessionId, authTokens, 60 * 60 * 24 * 1000); // 24 hours
+    await sessionCacheService.createSession(sessionId, authTokens, 60 * 60 * 24 * 1000); // 24 hours
 
     return { sessionId, data: {
       ...loginRes.data,
@@ -40,7 +40,7 @@ export class AuthService {
   }
 
   async logout(sessionId: string): Promise<IApiSuccessResponse<null>> {
-    const sessionData = await redisSessionService.getSession(sessionId);
+    const sessionData = await sessionCacheService.getSession(sessionId);
 
     if (!sessionData || !sessionData.accessToken) {
       throw new Error("You must be logged in to log out");
@@ -55,13 +55,13 @@ export class AuthService {
       withCredentials: true,
     });
 
-    await redisSessionService.deleteSession(sessionId);
+    await sessionCacheService.deleteSession(sessionId);
 
     return logoutRes.data;
   }
 
   async refresh(sessionId: string): Promise<{ sessionId: string; data: IApiSuccessResponse<null> }> {
-    const sessionData = await redisSessionService.getSession(sessionId);
+    const sessionData = await sessionCacheService.getSession(sessionId);
 
     if (!sessionData || !sessionData.refreshToken) {
       throw new Error("You must be logged in to refresh");
@@ -77,7 +77,7 @@ export class AuthService {
 
     const newAuthTokens = refreshRes.data.payload.data;
 
-    await redisSessionService.createSession(sessionId, newAuthTokens, 60 * 60 * 24 * 1000); // 24 hours
+    await sessionCacheService.createSession(sessionId, newAuthTokens, 60 * 60 * 24 * 1000); // 24 hours
 
     return { sessionId, data: {
       ...refreshRes.data,

--- a/apps/bff/src/modules/user/user.service.ts
+++ b/apps/bff/src/modules/user/user.service.ts
@@ -1,11 +1,11 @@
 import type { IApiSuccessResponse } from "@tubenote/types";
 
 import { axiosInstance } from "@/lib/axios";
-import { redisSessionService } from "@/services";
+import { sessionCacheService } from "@/services";
 
 export class UserService {
   async getCurrentUser(sessionId: string): Promise<IApiSuccessResponse<any>> {
-    const sessionData = await redisSessionService.getSession(sessionId);
+    const sessionData = await sessionCacheService.getSession(sessionId);
 
     if (!sessionData || !sessionData.accessToken) {
       throw new Error("You must be logged in to view your profile");

--- a/apps/bff/src/services/session-cache/cache.module.ts
+++ b/apps/bff/src/services/session-cache/cache.module.ts
@@ -1,3 +1,0 @@
-import { RedisSessionService } from "./cache.service";
-
-export const redisSessionService = new RedisSessionService();

--- a/apps/bff/src/services/session-cache/index.ts
+++ b/apps/bff/src/services/session-cache/index.ts
@@ -1,3 +1,3 @@
-export * from "./cache.module";
-export * from "./cache.service";
-export * from "./cache.types";
+export * from "./session-cache.module";
+export * from "./session-cache.service";
+export * from "./session-cache.types";

--- a/apps/bff/src/services/session-cache/session-cache.module.ts
+++ b/apps/bff/src/services/session-cache/session-cache.module.ts
@@ -1,0 +1,3 @@
+import { SessionCacheService } from "./session-cache.service";
+
+export const sessionCacheService = new SessionCacheService();

--- a/apps/bff/src/services/session-cache/session-cache.service.ts
+++ b/apps/bff/src/services/session-cache/session-cache.service.ts
@@ -1,11 +1,11 @@
-import Redis from "ioredis";
+import { RedisCacheService } from "@tubenote/redis-cache";
 
-import type { IRedisSessionService, ISessionData } from "./cache.types";
+import type { IRedisSessionService, ISessionData } from "./session-cache.types";
 
 import { envConfig } from "../../config";
 
-export class RedisSessionService implements IRedisSessionService {
-  private client: Redis;
+export class SessionCacheService implements IRedisSessionService {
+  private redisCache: RedisCacheService;
 
   /**
    * Initializes the cache service with a Redis client connection.
@@ -19,14 +19,12 @@ export class RedisSessionService implements IRedisSessionService {
    * @throws {Error} If Redis connection fails or configuration is invalid
    */
   constructor() {
-    this.client = new Redis({
+    this.redisCache = new RedisCacheService({
       host: envConfig.redis.host,
       port: +envConfig.redis.port,
       password: envConfig.redis.password,
       maxRetriesPerRequest: 3,
     });
-
-    this.client.on("error", err => console.error("Redis Client Error", err));
   }
 
   /**
@@ -44,15 +42,7 @@ export class RedisSessionService implements IRedisSessionService {
    * - Uses Redis SET command with EX flag for automatic expiration
    */
   async createSession(sessionId: string, data: ISessionData, ttl: number): Promise<boolean> {
-    console.log(`Cache: Creating session for ID: ${sessionId} with TTL: ${ttl}`);
-
-    if (!sessionId || !data) {
-      console.warn("Cache: Attempted to create session with invalid ID or data");
-      return false;
-    }
-
-    const result = await this.client.set(sessionId, JSON.stringify(data), "EX", ttl);
-    return result === "OK";
+    return this.redisCache.set(sessionId, data, ttl);
   }
 
   /**
@@ -67,17 +57,8 @@ export class RedisSessionService implements IRedisSessionService {
    * - Parses the stored JSON string back into an object
    * - Logs a warning when attempting to retrieve with an empty session ID
    */
-  async getSession(sessionId: string): Promise<ISessionData | null> {
-    console.log(`Cache: Retrieving session for ID: ${sessionId}`);
-
-    if (!sessionId) {
-      console.warn("Cache: Attempted to retrieve session with empty ID");
-      return null;
-    }
-
-    const data = await this.client.get(sessionId);
-
-    return data ? JSON.parse(data) : null;
+  async getSession(sessionId: string): Promise<ISessionData | undefined> {
+    return this.redisCache.get(sessionId);
   }
 
   /**
@@ -98,13 +79,6 @@ export class RedisSessionService implements IRedisSessionService {
    * ```
    */
   async deleteSession(sessionId: string): Promise<number> {
-    console.log(`Cache: Deleting session for ID: ${sessionId}`);
-
-    if (!sessionId) {
-      console.warn("Cache: Attempted to delete a session with empty ID");
-      return 0;
-    }
-
-    return this.client.del(sessionId);
+    return this.redisCache.del(sessionId);
   }
 }

--- a/apps/bff/src/services/session-cache/session-cache.types.ts
+++ b/apps/bff/src/services/session-cache/session-cache.types.ts
@@ -28,9 +28,9 @@ export interface IRedisSessionService {
    * Retrieves session data from Redis by session ID.
    *
    * @param sessionId - Unique identifier for the session to retrieve
-   * @returns Promise that resolves to session data if found, null if session doesn't exist or has expired
+   * @returns Promise that resolves to session data if found, undefined if session doesn't exist or has expired
    */
-  getSession: (sessionId: string) => Promise<ISessionData | null>;
+  getSession: (sessionId: string) => Promise<ISessionData | undefined>;
 
   /**
    * Deletes a session from Redis by session ID.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tubenote/api-errors": "workspace:*",
+    "@tubenote/redis-cache": "workspace:*",
     "@tubenote/db": "workspace:*",
     "@tubenote/dtos": "workspace:*",
     "@tubenote/schemas": "workspace:*",
@@ -31,7 +32,6 @@
     "helmet": "^8.0.0",
     "http-status": "^1.7.4",
     "inversify": "^7.5.1",
-    "ioredis": "^5.6.1",
     "jsonwebtoken": "^9.0.2",
     "node-cache": "^5.1.2",
     "nodemailer": "^6.9.16",

--- a/apps/server/src/modules/shared/services/cache/cache.service.ts
+++ b/apps/server/src/modules/shared/services/cache/cache.service.ts
@@ -1,5 +1,5 @@
+import { RedisCacheService } from "@tubenote/redis-cache";
 import { inject, injectable } from "inversify";
-import Redis from "ioredis";
 
 import { TYPES } from "@/config/inversify/types";
 
@@ -10,7 +10,7 @@ import { envConfig } from "../../config";
 
 @injectable()
 export class CacheService implements ICacheService {
-  private client: Redis;
+  private redisCache: RedisCacheService;
 
   /**
    * Initializes the cache service with a Redis client connection.
@@ -24,14 +24,12 @@ export class CacheService implements ICacheService {
    * @throws {Error} If Redis connection fails or configuration is invalid
    */
   constructor(@inject(TYPES.LoggerService) private logger: ILoggerService) {
-    this.client = new Redis({
+    this.redisCache = new RedisCacheService({
       host: envConfig.redis.host,
       port: +envConfig.redis.port,
       password: envConfig.redis.password,
       maxRetriesPerRequest: 3,
     });
-
-    this.client.on("error", err => console.error("Redis Client Error", err));
   }
 
   /**
@@ -43,19 +41,7 @@ export class CacheService implements ICacheService {
    *
    */
   async get<T>(key: string): Promise<T | undefined> {
-    this.logger.debug(`Cache: Retrieving value for key: ${key}`);
-
-    if (!key) {
-      this.logger.warn("Cache: Attempted to get value for an empty key");
-      return undefined;
-    }
-
-    const data = await this.client.get(key);
-    if (data) {
-      return JSON.parse(data) as T;
-    }
-
-    return undefined;
+    return this.redisCache.get<T>(key);
   }
 
   /**
@@ -69,20 +55,7 @@ export class CacheService implements ICacheService {
    *
    */
   async set<T>(key: string, value: T, ttl?: number): Promise<boolean> {
-    this.logger.debug(`Cache: Setting value for key: ${key} with TTL: ${ttl}`);
-
-    if (typeof value === "undefined" || value === null) {
-      this.logger.warn(`Cache: Attempted to set undefined or null value for key: ${key}`);
-      return false;
-    }
-
-    const stringValue = JSON.stringify(value);
-    if (ttl) {
-      const result = await this.client.set(key, stringValue, "EX", ttl);
-      return result === "OK";
-    }
-    const result = await this.client.set(key, stringValue);
-    return result === "OK";
+    return this.redisCache.set(key, value, ttl);
   }
 
   /**
@@ -92,14 +65,7 @@ export class CacheService implements ICacheService {
    * @returns A promise that resolves to the number of keys that were deleted (0 or 1)
    */
   async del(key: string): Promise<number> {
-    this.logger.debug(`Cache: Deleting key: ${key}`);
-
-    if (!key) {
-      this.logger.warn("Cache: Attempted to delete an empty key");
-      return 0;
-    }
-
-    return this.client.del(key);
+    return this.redisCache.del(key);
   }
 
   /**
@@ -110,9 +76,7 @@ export class CacheService implements ICacheService {
    * @throws {Error} If the cache client is not available or the flush operation fails
    */
   async flush(): Promise<void> {
-    this.logger.debug("Cache: Flushing all keys from the cache");
-
-    await this.client.flushall();
+    await this.redisCache.flush();
   }
 
   /**
@@ -133,24 +97,6 @@ export class CacheService implements ICacheService {
    * ```
    */
   async getStats(): Promise<any> {
-    const info = await this.client.info();
-    // Parse the info string to get relevant stats
-    const lines = info.split("\r\n");
-    const stats: Record<string, any> = {};
-
-    lines.forEach((line) => {
-      if (line && !line.startsWith("#")) {
-        const parts = line.split(":");
-        if (parts.length === 2) {
-          stats[parts[0]] = parts[1];
-        }
-      }
-    });
-
-    return {
-      keys: stats.db0 ? +stats.db0.split(",")[0].split("=")[1] : 0,
-      hits: +stats.keyspace_hits,
-      misses: +stats.keyspace_misses,
-    };
+    return this.redisCache.getStats();
   }
 }

--- a/packages/redis-cache/.gitignore
+++ b/packages/redis-cache/.gitignore
@@ -1,0 +1,11 @@
+# dependencies
+/node_modules
+
+# production
+/dist
+
+# local env files
+.env
+
+# typescript
+*.tsbuildinfo

--- a/packages/redis-cache/README.md
+++ b/packages/redis-cache/README.md
@@ -1,0 +1,23 @@
+# @tubenote/redis-cache
+
+A shared Redis cache service for the TubeNote platform.
+
+## Features
+
+- Singleton Redis client
+- Basic cache operations (get, set, del)
+- Statistics reporting
+
+## Usage
+
+```typescript
+import { RedisCacheService } from "@tubenote/redis-cache";
+
+const cacheService = new RedisCacheService({
+  host: "localhost",
+  port: 6379,
+});
+
+await cacheService.set("my-key", { foo: "bar" }, 60);
+const value = await cacheService.get("my-key");
+```

--- a/packages/redis-cache/package.json
+++ b/packages/redis-cache/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tubenote/redis-cache",
+  "version": "1.0.0",
+  "description": "A shared Redis cache service for TubeNote.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "ioredis": "^5.6.1"
+  },
+  "devDependencies": {
+    "@tubenote/config-typescript": "workspace:*",
+    "typescript": "^5.7.2",
+    "tsup": "^8.4.0",
+    "@types/node": "^20.2.3"
+  }
+}

--- a/packages/redis-cache/src/index.ts
+++ b/packages/redis-cache/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./service";

--- a/packages/redis-cache/src/service/index.ts
+++ b/packages/redis-cache/src/service/index.ts
@@ -1,0 +1,2 @@
+export * from "./redis-cache.service";
+export * from "./redis-cache.types";

--- a/packages/redis-cache/src/service/redis-cache.service.ts
+++ b/packages/redis-cache/src/service/redis-cache.service.ts
@@ -1,0 +1,150 @@
+import type { RedisOptions } from "ioredis";
+
+import Redis from "ioredis";
+
+import type { IRedisCacheService } from "./redis-cache.types";
+
+export class RedisCacheService implements IRedisCacheService {
+  private client: Redis;
+
+  /**
+   * Initializes the cache service with a Redis client connection.
+   *
+   * Sets up a Redis client using configuration from envConfig with the following settings:
+   * - Host and port from environment configuration
+   * - Password authentication if provided
+   * - Maximum of 3 retry attempts per request
+   * - Error event listener for logging Redis connection errors
+   *
+   * @throws {Error} If Redis connection fails or configuration is invalid
+   */
+  constructor(redisOptions: RedisOptions) {
+    this.client = new Redis(redisOptions);
+
+    this.client.on("error", err => console.error("Redis Client Error", err));
+  }
+
+  /**
+   * Retrieves a value from the cache by key and deserializes it from JSON.
+   *
+   * @template T - The expected type of the cached value
+   * @param key - The cache key to retrieve the value for
+   * @returns A promise that resolves to the cached value of type T, or undefined if the key doesn't exist
+   *
+   */
+  async get<T>(key: string): Promise<T | undefined> {
+    // this.logger.debug(`Cache: Retrieving value for key: ${key}`);
+
+    if (!key) {
+      // this.logger.warn("Cache: Attempted to get value for an empty key");
+      return undefined;
+    }
+
+    const data = await this.client.get(key);
+
+    if (data) {
+      return JSON.parse(data) as T;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Sets a value in the cache with an optional time-to-live (TTL).
+   *
+   * @template T - The type of the value to be cached
+   * @param key - The cache key to store the value under
+   * @param value - The value to be cached (will be JSON serialized)
+   * @param ttl - Optional time-to-live in seconds. If provided, the key will expire after this duration
+   * @returns A promise that resolves to true if the operation was successful, false otherwise
+   *
+   */
+  async set<T>(key: string, value: T, ttl?: number): Promise<boolean> {
+    // this.logger.debug(`Cache: Setting value for key: ${key} with TTL: ${ttl}`);
+
+    if (typeof value === "undefined" || value === null) {
+      // this.logger.warn(`Cache: Attempted to set undefined or null value for key: ${key}`);
+      return false;
+    }
+
+    const stringValue = JSON.stringify(value);
+
+    if (ttl) {
+      const result = await this.client.set(key, stringValue, "EX", ttl);
+      return result === "OK";
+    }
+
+    const result = await this.client.set(key, stringValue);
+
+    return result === "OK";
+  }
+
+  /**
+   * Deletes a key from the cache.
+   *
+   * @param key - The cache key to delete
+   * @returns A promise that resolves to the number of keys that were deleted (0 or 1)
+   */
+  async del(key: string): Promise<number> {
+    // this.logger.debug(`Cache: Deleting key: ${key}`);
+
+    if (!key) {
+      // this.logger.warn("Cache: Attempted to delete an empty key");
+      return 0;
+    }
+
+    return this.client.del(key);
+  }
+
+  /**
+   * Flushes all data from the cache by removing all keys from all databases.
+   * This operation is irreversible and will permanently delete all cached data.
+   *
+   * @returns A promise that resolves when the flush operation is complete
+   * @throws {Error} If the cache client is not available or the flush operation fails
+   */
+  async flush(): Promise<void> {
+    // this.logger.debug("Cache: Flushing all keys from the cache");
+
+    await this.client.flushall();
+  }
+
+  /**
+   * Retrieves Redis cache statistics including key count, hits, and misses.
+   *
+   * This method fetches Redis server information and parses it to extract
+   * relevant cache performance metrics.
+   *
+   * @returns {Promise<any>} A promise that resolves to an object containing:
+   * - `keys`: Number of keys in database 0 (defaults to 0 if db0 doesn't exist)
+   * - `hits`: Total number of cache hits (keyspace_hits)
+   * - `misses`: Total number of cache misses (keyspace_misses)
+   *
+   * @example
+   * ```typescript
+   * const stats = await cacheService.getStats();
+   * console.log(`Cache has ${stats.keys} keys with ${stats.hits} hits and ${stats.misses} misses`);
+   * ```
+   */
+  async getStats(): Promise<any> {
+    const info = await this.client.info();
+    // Parse the info string to get relevant stats
+    const lines = info.split("\r\n");
+    const stats: Record<string, any> = {};
+
+    lines.forEach((line) => {
+      if (line && !line.startsWith("#")) {
+        const parts = line.split(":");
+        if (parts.length === 2) {
+          stats[parts[0]] = parts[1];
+        }
+      }
+    });
+
+    return {
+      keys: stats.db0 ? +stats.db0.split(",")[0].split("=")[1] : 0,
+      hits: +stats.keyspace_hits,
+      misses: +stats.keyspace_misses,
+    };
+  }
+}

--- a/packages/redis-cache/src/service/redis-cache.types.ts
+++ b/packages/redis-cache/src/service/redis-cache.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Interface for cache service operations providing basic cache functionality
+ * with support for storing, retrieving, and managing cached data with TTL support.
+ */
+export interface IRedisCacheService {
+  /**
+   * Stores a value in the cache with an optional time-to-live (TTL).
+   * @template T - The type of the value to be cached
+   * @param key - The unique identifier for the cached value
+   * @param value - The value to store in the cache
+   * @param ttl - Optional time-to-live in seconds. If not provided, uses default TTL
+   * @returns Promise that resolves to true if the value was successfully stored, false otherwise
+   */
+  set: <T>(key: string, value: T, ttl?: number) => Promise<boolean>;
+
+  /**
+   * Retrieves a value from the cache by its key.
+   * @template T - The expected type of the cached value
+   * @param key - The unique identifier for the cached value
+   * @returns Promise that resolves to the cached value if found, undefined otherwise
+   */
+  get: <T>(key: string) => Promise<T | undefined>;
+
+  /**
+   * Removes a value from the cache by its key.
+   * @param key - The unique identifier for the cached value to remove
+   * @returns Promise that resolves to the number of keys that were removed (0 or 1)
+   */
+  del: (key: string) => Promise<number>;
+
+  /**
+   * Clears all cached values from the cache storage.
+   * @returns Promise that resolves when all cached data has been successfully cleared
+   */
+  flush: () => Promise<void>;
+
+  /**
+   * Retrieves cache statistics and performance metrics.
+   * @returns Promise that resolves to an object containing cache statistics such as hit/miss ratios, memory usage, etc.
+   */
+  getStats: () => Promise<any>;
+}

--- a/packages/redis-cache/tsconfig.json
+++ b/packages/redis-cache/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tubenote/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/redis-cache/tsup.config.ts
+++ b/packages/redis-cache/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  shims: true,
+});


### PR DESCRIPTION
This pull request introduces a shared Redis cache service (`@tubenote/redis-cache`) to centralize caching functionality across the TubeNote platform. It replaces direct usage of `ioredis` with the new service in both the `bff` and `server` applications, refactoring their cache implementations for improved maintainability and consistency. The most important changes include the creation of the `@tubenote/redis-cache` package, refactoring cache-related services in the `bff` and `server` applications, and updating dependencies.

### Creation of `@tubenote/redis-cache` package:
* [`packages/redis-cache/package.json`](diffhunk://#diff-a9dda08aaa308e5731cdf5b0e58b7abe68952640273d6f9744a1df821162f08fR1-R25): Added a new package with `ioredis` as a dependency and TypeScript build scripts.
* [`packages/redis-cache/src/service/redis-cache.service.ts`](diffhunk://#diff-e7d7f2f2a26f70fffa7f17c651d70a718cf16877edbecacbdc6b309aa38b5881R1): Implemented the `RedisCacheService` class with methods for cache operations (`get`, `set`, `del`, `flush`, `getStats`). [[1]](diffhunk://#diff-e7d7f2f2a26f70fffa7f17c651d70a718cf16877edbecacbdc6b309aa38b5881R1) [[2]](diffhunk://#diff-5497ce8733fa5aef55e59e20ba25812bd9e75da9694d08f1e7e623ab558f2faeR1-R2)
* [`packages/redis-cache/README.md`](diffhunk://#diff-2085422466706dc2a517fd8be3e6e0e0ebfac1d13ff58053b1281c9b49e2dc78R1-R23): Documented usage and features of the Redis cache service.

### Refactoring in `bff` application:
* [`apps/bff/src/services/session-cache/session-cache.service.ts`](diffhunk://#diff-2d944774db7f36e3afa52e180fedab9234915fe4566f1c86343606da2e4e37baL1-R8): Renamed and refactored the `RedisSessionService` to use `RedisCacheService` for all session-related operations (`getSession`, `createSession`, `deleteSession`). [[1]](diffhunk://#diff-2d944774db7f36e3afa52e180fedab9234915fe4566f1c86343606da2e4e37baL1-R8) [[2]](diffhunk://#diff-2d944774db7f36e3afa52e180fedab9234915fe4566f1c86343606da2e4e37baL47-R45) [[3]](diffhunk://#diff-2d944774db7f36e3afa52e180fedab9234915fe4566f1c86343606da2e4e37baL101-R82)
* [`apps/bff/src/modules/auth/auth.service.ts`](diffhunk://#diff-a2e00d5a24c904d5596615c754842b19d23071d2a2fcf95bdbe9d7251400eff0L11-R15): Updated `AuthService` to use `sessionCacheService` instead of `redisSessionService`. [[1]](diffhunk://#diff-a2e00d5a24c904d5596615c754842b19d23071d2a2fcf95bdbe9d7251400eff0L11-R15) [[2]](diffhunk://#diff-a2e00d5a24c904d5596615c754842b19d23071d2a2fcf95bdbe9d7251400eff0L58-R64)
* [`apps/bff/package.json`](diffhunk://#diff-e64e52d6231846c87709af41dc5edb1dfd4980367abf3b644efc9babee189585R15): Replaced `ioredis` with `@tubenote/redis-cache` as a dependency. [[1]](diffhunk://#diff-e64e52d6231846c87709af41dc5edb1dfd4980367abf3b644efc9babee189585R15) [[2]](diffhunk://#diff-e64e52d6231846c87709af41dc5edb1dfd4980367abf3b644efc9babee189585L23)

### Refactoring in `server` application:
* [`apps/server/src/modules/shared/services/cache/cache.service.ts`](diffhunk://#diff-e9bc4a4efe1a4ebe0fee049884ee5ed3c5bf289f50e7dfeaaadd0402ec981b03R1-L2): Refactored the `CacheService` to use `RedisCacheService` for all cache operations (`get`, `set`, `del`, `flush`, `getStats`). [[1]](diffhunk://#diff-e9bc4a4efe1a4ebe0fee049884ee5ed3c5bf289f50e7dfeaaadd0402ec981b03R1-L2) [[2]](diffhunk://#diff-e9bc4a4efe1a4ebe0fee049884ee5ed3c5bf289f50e7dfeaaadd0402ec981b03L46-R44) [[3]](diffhunk://#diff-e9bc4a4efe1a4ebe0fee049884ee5ed3c5bf289f50e7dfeaaadd0402ec981b03L136-R100)
* [`apps/server/package.json`](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R16): Replaced `ioredis` with `@tubenote/redis-cache` as a dependency. [[1]](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2R16) [[2]](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2L34)

### Dependency updates:
* Removed `ioredis` from `bff` and `server` applications and added `@tubenote/redis-cache` as a dependency in their `package.json` files. [[1]](diffhunk://#diff-e64e52d6231846c87709af41dc5edb1dfd4980367abf3b644efc9babee189585L23) [[2]](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2L34)

These changes improve code reuse, reduce redundancy, and simplify cache-related operations across the platform.