### PR TITLE
refactor(server): streamline error handling, update refresh token repo, and enhance crypto utilities

### DIFF
--- a/apps/server/src/modules/auth/features/local-auth/local-auth.service.ts
+++ b/apps/server/src/modules/auth/features/local-auth/local-auth.service.ts
@@ -4,8 +4,6 @@ import type { ILoginDto, IRegisterDto } from "@tubenote/dtos";
 import {
   ERROR_MESSAGES,
   ForbiddenError,
-  NotFoundError,
-  UnauthorizedError,
 } from "@tubenote/api-errors";
 import { inject, injectable } from "inversify";
 
@@ -91,29 +89,17 @@ export class LocalAuthService implements ILocalAuthService {
 
     // Get the user first to check if they exist
     const user = await this._userService.getUserByEmail(email);
+    let isPasswordValid = false;
 
-    if (!user) {
-      this._loggerService.warn("Login attempt with non-existent email", {
-        email,
+    if (user) {
+      isPasswordValid = await this._cryptoService.validateHashMatch({
+        unhashedValue: password,
+        hashedValue: user.password,
       });
-
-      throw new NotFoundError(ERROR_MESSAGES.RESOURCE_NOT_FOUND);
     }
 
-    if (!user.isEmailVerified) {
-      throw new UnauthorizedError(ERROR_MESSAGES.NOT_VERIFIED);
-    }
-
-    const isPasswordMatch = await this._cryptoService.validateHashMatch({
-      unhashedValue: password,
-      hashedValue: user.password,
-    });
-
-    if (!isPasswordMatch) {
-      this._loggerService.warn("Failed login attempt - invalid password", {
-        userId: user.id,
-        email,
-      });
+    if (!user || !isPasswordValid || !user.isEmailVerified) {
+      this._loggerService.warn("Invalid login attempt");
 
       throw new ForbiddenError(ERROR_MESSAGES.INVALID_CREDENTIALS);
     }
@@ -128,10 +114,7 @@ export class LocalAuthService implements ILocalAuthService {
 
     const accessToken = this._jwtService.generateAccessToken(user.id);
 
-    this._loggerService.info("User logged in successfully", {
-      userId: user.id,
-      email,
-    });
+    this._loggerService.info("User logged in successfully");
 
     return { accessToken, refreshToken };
   }

--- a/apps/server/src/modules/auth/features/refresh-token/refresh-token.repository.ts
+++ b/apps/server/src/modules/auth/features/refresh-token/refresh-token.repository.ts
@@ -58,7 +58,7 @@ export class RefreshTokenRepository implements IRefreshTokenRepository {
 
     return handleAsyncOperation(
       () =>
-        client.refreshToken.findUnique({
+        client.refreshToken.findFirst({
           where: {
             token,
             expiresAt: { gt: new Date() },
@@ -73,6 +73,7 @@ export class RefreshTokenRepository implements IRefreshTokenRepository {
    * Marks a refresh token as revoked in the database.
    *
    * @param tokenId - The ID of the token to be marked as revoked.
+   * @param revocationReason - The reason for revoking the token.
    * @param tx - Optional transaction client for database operations.
    *
    * @returns A promise that resolves when the token is successfully marked as revoked.

--- a/apps/server/src/modules/shared/services/crypto/crypto.service.ts
+++ b/apps/server/src/modules/shared/services/crypto/crypto.service.ts
@@ -1,10 +1,11 @@
-import crypto from "node:crypto";
 import bcrypt from "bcryptjs";
-
 import { injectable } from "inversify";
-import { envConfig } from "../../config";
+import { createHash, randomBytes } from "node:crypto";
+
 import type { ICryptoService } from "./crypto.types";
 import type { HashValidationDto } from "./dtos";
+
+import { envConfig } from "../../config";
 
 @injectable()
 export class CryptoService implements ICryptoService {
@@ -13,7 +14,7 @@ export class CryptoService implements ICryptoService {
 
   /**
    * Hashes a plain-text password.
-   * @param password - The plain-text password to hash.
+   * @param rawValue - The plain-text password to hash.
    * @returns The hashed password.
    */
   async generateHash(rawValue: string): Promise<string> {
@@ -24,25 +25,47 @@ export class CryptoService implements ICryptoService {
 
   /**
    * Compares a plain-text password with a hashed password.
-   * @param password - The plain-text password.
-   * @param hashedPassword - The hashed password to compare with.
+   * @param hashValidationDto - The DTO containing the values to compare.
    * @returns True if the passwords match, false otherwise.
    */
   async validateHashMatch(
-    hashValidationDto: HashValidationDto
+    hashValidationDto: HashValidationDto,
   ): Promise<boolean> {
     const { unhashedValue, hashedValue } = hashValidationDto;
 
     return await bcrypt.compare(unhashedValue, hashedValue);
   }
 
+  /**
+   * Generates a cryptographically secure random token as a hexadecimal string.
+   *
+   * @returns {string} A securely generated random token in hexadecimal format.
+   */
   generateSecureToken(): string {
-    return crypto.randomBytes(this.TOKEN_BYTES).toString("hex");
+    return randomBytes(this.TOKEN_BYTES).toString("hex");
   }
 
+  /**
+   * Generates an unsalted hash from a raw string value using the configured hash algorithm.
+   *
+   * @param rawValue - The raw string value to be hashed
+   * @returns A hexadecimal string representation of the hash
+   *
+   * @remarks
+   * This method uses the hash algorithm specified in the environment configuration.
+   * Since this is an unsalted hash, identical input values will always produce
+   * identical hash outputs, making it suitable for deterministic hashing scenarios
+   * but potentially vulnerable to rainbow table attacks.
+   *
+   * @example
+   * ```typescript
+   * const hash = cryptoService.generateUnsaltedHash('myPassword');
+   * console.log(hash); // e.g., "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+   * ```
+   */
   generateUnsaltedHash(rawValue: string): string {
-    const hashAlgorithm = envConfig.crypto.hash_algorithm;
-
-    return crypto.hash(hashAlgorithm, rawValue, "hex");
+    return createHash(envConfig.crypto.hash_algorithm)
+      .update(rawValue, "utf8")
+      .digest("hex");
   }
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the authentication and crypto services, focusing on streamlining error handling, improving password validation logic, and enhancing cryptographic utilities. The most significant changes include consolidating login error handling, updating the refresh token repository query, and refactoring the crypto service for clarity and security.

**Authentication logic improvements:**

* Consolidated login error handling in `LocalAuthService` to use a single `ForbiddenError` for invalid credentials, replacing multiple error types and logging a generic warning for all invalid login attempts. This also refactors password validation logic to only check if the user exists before validating the password. (`apps/server/src/modules/auth/features/local-auth/local-auth.service.ts`)
* Simplified login success logging to remove user-specific details from the log message. (`apps/server/src/modules/auth/features/local-auth/local-auth.service.ts`)
* Removed unused error imports (`NotFoundError`, `UnauthorizedError`) from `local-auth.service.ts`. (`apps/server/src/modules/auth/features/local-auth/local-auth.service.ts`)

**Refresh token repository update:**

* Changed the refresh token query from `findUnique` to `findFirst` to ensure correct retrieval of valid tokens. (`apps/server/src/modules/auth/features/refresh-token/refresh-token.repository.ts`)
* Updated documentation for the `markAsRevoked` method to include an optional `revocationReason` parameter. (`apps/server/src/modules/auth/features/refresh-token/refresh-token.repository.ts`)

**Crypto service refactor and enhancement:**

* Replaced direct `crypto` import with selective imports (`createHash`, `randomBytes`), and improved method signatures and documentation for password hashing and validation. Added a new `generateUnsaltedHash` method for deterministic hashing using the configured algorithm. (`apps/server/src/modules/shared/services/crypto/crypto.service.ts`) [[1]](diffhunk://#diff-4912959816c2f2553caf012a731de89f9d213c1fdc7242b7c6857f0fd07b4dceL1-R17) [[2]](diffhunk://#diff-4912959816c2f2553caf012a731de89f9d213c1fdc7242b7c6857f0fd07b4dceL27-R69)